### PR TITLE
modify serviceBus configuration to launch this workspace on Apple Silicon Mac

### DIFF
--- a/AppHost/Program.cs
+++ b/AppHost/Program.cs
@@ -1,11 +1,41 @@
+using System.Runtime.InteropServices;
 using Aspire.Hosting;
+using Aspire.Hosting.Azure;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-// Add Service Bus with emulator and create topic
-var serviceBus = builder.AddAzureServiceBus("messaging")
-    .RunAsEmulator();
+var serviceBus = builder.AddAzureServiceBus("messaging");
+
+// workaround for [this issue](https://github.com/dotnet/aspire/issues/8818)
+if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.OSArchitecture == Architecture.Arm64)
+{
+    // Add Service Bus with emulator and create topic
+    serviceBus.RunAsEmulator(sb =>
+        {
+            sb.WithHttpEndpoint(targetPort: 5300, name: "sbhealthendpoint")
+                .WithImageTag("1.1.2")
+                .WithContainerName("messaging")
+                .WithEnvironment("SQL_WAIT_INTERVAL", "1");
+
+            var edge = sb.ApplicationBuilder.Resources.OfType<ContainerResource>()
+                .First(resource => resource.Name.EndsWith("-sqledge"));
+
+            var annotation = edge.Annotations.OfType<ContainerImageAnnotation>().First();
+
+            annotation.Image = "mssql/server";
+            annotation.Tag = "2022-latest";
+        });
+
+    var sbHc = serviceBus.Resource.Annotations.OfType<HealthCheckAnnotation>().First();
+    serviceBus.Resource.Annotations.Remove(sbHc);
+
+    serviceBus.WithHttpHealthCheck("/health", 200, "sbhealthendpoint");
+}
+else
+{
+    serviceBus.RunAsEmulator();
+}
 
 var loanDrafts = builder.AddRedis("loan-drafts");
 var loanDatabase = builder.AddRedis("loan-database");


### PR DESCRIPTION
## Why

I cannot launch this workspace on Rider with Apple Silicon Mac.

It is because `messaging-sqledge` which is created when `messaging` container is launched automatically is failed to launch due to [this issue](https://github.com/dotnet/aspire/issues/8818).

It is related to be not able to launch `azure-sql-edge` image on Apple Silicon Mac.

## How

I applied to use `mssql/server` image instead of `azure-sql-edge` image when the host machine is Apple Silicon Mac.

It is workaround which is mentioned by above issue.